### PR TITLE
Update sdram_test.py for current version of LiteX

### DIFF
--- a/rv901t/sdram_test.py
+++ b/rv901t/sdram_test.py
@@ -57,7 +57,7 @@ class SDRAMTest(SoCSDRAM):
         sys_clk_freq = int(75e6)
 
         # SoCSDRAM ---------------------------------------------------------------------------------
-        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, integrated_rom_size=0x6000)
+        SoCSDRAM.__init__(self, platform, cpu_type = "vexriscv", cpu_variant = "minimal", clk_freq = sys_clk_freq, integrated_rom_size = 0x8000)
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq)


### PR DESCRIPTION
Update sdram_test.py in order to successfully compile again with current version of [LiteX](https://github.com/enjoy-digital/litex/tree/fa5fd765a4fdc1c4c820e2af6180626c763db076).
See issue #86