### PR TITLE
Update rgmii_test.py for current version of LiteX

### DIFF
--- a/rv901t/rgmii_test.py
+++ b/rv901t/rgmii_test.py
@@ -44,7 +44,8 @@ class RGMIITest(SoCMini):
         # phy
         ethphy = LiteEthPHYRGMII(
             clock_pads = platform.request("eth_clocks", eth_phy),
-            pads       = platform.request("eth", eth_phy))
+            pads       = platform.request("eth", eth_phy),
+            tx_delay   = 0e-9)
         # core
         ethcore = LiteEthUDPIPCore(
             phy         = ethphy,


### PR DESCRIPTION
the tx_delay needs to be specified (default value has changed), see #86.