### PR TITLE
5A-75E V8/V6 pinout fix, along with a few notes.

### DIFF
--- a/5a-75e/README.md
+++ b/5a-75e/README.md
@@ -4,7 +4,7 @@ The Colorlight 5A-75E is an updated version of 5A-75B with 16 HUB75 ports. It al
 
 There are 2 known versions available on the market at this time:
 
-* V6.0: LFE5U-25F with CABGA256 package. [Detailed info](hardware_V6.0.md).
+* V6.0/V8.0: LFE5U-25F with CABGA256 package. [Detailed info](hardware_V6.0.md).
 * V7.1: LFE5U-25F with CABGA256 package. [Detailed info](hardware_V7.1.md).
 
 The V6.0 board has the following components in addition to the FPGA:

--- a/5a-75e/hardware_V6.0.md
+++ b/5a-75e/hardware_V6.0.md
@@ -201,6 +201,20 @@ For each connector, the address, CLK, STB/LAT, and OE bits are shared:
 | N1        | 14        | STB
 | M4        | 15        | OE
 
+#### LED Transceivers to J* mapping
+
+Transceivers U23,U24,U28 completely cover RGB pins on J1,J2,J3,J4
+
+Transceivers U25,U26,U27 completely cover RGB pins on J5,J6,J7,J8
+
+Transceivers U14,U16,U18 completely cover RGB pins on	J9,J10,J11,J12
+
+Transceivers U9,U12,U15 completely cover RGB pins on J13,J14,J15,J16
+
+Transceivers U10,U11,U13,U17,U19,U20,U21,U22,U30,U38,U39 cover all shared pins
+
+
+
 The RBG bits are unique per connector:
 
 #### LED J1

--- a/5a-75e/hardware_V6.0.md
+++ b/5a-75e/hardware_V6.0.md
@@ -372,7 +372,7 @@ The RBG bits are unique per connector:
 
 | FPGA Pin  | HUB75 Pin | Function |
 |-----------|-----------|----------|
-| F14       | 1         | R0
+| G14       | 1         | R0
 | G13       | 2         | G0
 | F12       | 3         | B0
 | F13       | 5         | R1

--- a/5a-75e/hardware_V6.0.md
+++ b/5a-75e/hardware_V6.0.md
@@ -1,4 +1,6 @@
-# Colorlight 5A-75E V6.0 Hardware
+# Colorlight 5A-75E V6.0/V8.0 Hardware
+
+Both V6.0 and V8.0 appear to have the same pinout.
 
 * [Front image](images/cl-5a-75e-v60-front.jpg)
 * [Back image](images/cl-5a-75e-v60-back.jpg)


### PR DESCRIPTION
* Corrected Pin 1 of J16
* Added a clarification regarding V8.0 and V6.0 having the same pinout.
* Added a note about which connector associate with which transceiver.